### PR TITLE
Unifying the IO site

### DIFF
--- a/Challenge-12/ReadMe.md
+++ b/Challenge-12/ReadMe.md
@@ -103,4 +103,4 @@ Success is seeing actual human images in your stuides in the DICOM Service.
 
 The bonus part of the challenge is to repeat your path but this time deploy the OSS Medical Imageing Server for DICOM. You have already cloned the repo for the tools.
 
-Tip - The GitHub repo site has an Deploy to Azure button built in.
+Tip - The GitHub repo site has a Deploy to Azure button built in.

--- a/Challenge-12/ReadMe.md
+++ b/Challenge-12/ReadMe.md
@@ -13,7 +13,7 @@ Research is broadening beyond text based research. These research initiatives re
 ## Learning Objectives
 
 - Setup a DICOM instance within Azure Healthcare APIs
-- Submit a DICOM files to the service
+- Submit DICOM files to the service
 - Successfully view the files with a DICOM viewer connected to the Azure Healthcare APIs
 
 *Note: Azure Healthcare APIs is still in Public Preview. For customers looking to move to production prior to GA please use the OSS Imaging Service or contact this team.*

--- a/docs/Challenge-2.md
+++ b/docs/Challenge-2.md
@@ -8,10 +8,10 @@ nav_order: 2
 # Microsoft Cloud for Healthcare OpenHack
 ## Convert HL7 and C-CDA to FHIR
 
+[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-02){: .btn }
+
 Many organizations have existing data solutions built around legacy specs. HL7 and C-CDA are two of the most common legacy formats. To ease our customers' way to FHIR we provide conversion support from both HL7 and C-CDA. This challenge will walk you through using this conversion support.
 
-
-[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-02){: .btn }
 
 ## Challenge 
 + Convert HL7 and C-CDA data to a FHIR bundle with $convert-data

--- a/docs/Challenge-2.md
+++ b/docs/Challenge-2.md
@@ -1,16 +1,19 @@
 ---
-title: 2) Convert HL7 to FHIR
+title: 2) Convert HL7 and C-CDA to FHIR
 parent: FHIR Basics
 has_children: false
 nav_order: 2
 ---
 
 # Microsoft Cloud for Healthcare OpenHack
-## Convert HL7 to FHIR
+## Convert HL7 and C-CDA to FHIR
+
+Many organizations have existing data solutions built around legacy specs. HL7 and C-CDA are two of the most common legacy formats. To ease our customers' way to FHIR we provide conversion support from both HL7 and C-CDA. This challenge will walk you through using this conversion support.
+
 
 [View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-02){: .btn }
 
 ## Challenge 
-+ Prepare data for conversion into FHIR
++ Convert HL7 and C-CDA data to a FHIR bundle with $convert-data
 
-Access the __Convert HL7 to FHIR Challenge__ **[here](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-02)**.
+Access the __Convert HL7 and C-CDA to FHIR Challenge__ **[here](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-02)**.

--- a/docs/Challenge-3.md
+++ b/docs/Challenge-3.md
@@ -8,6 +8,7 @@ nav_order: 3
 # Microsoft Cloud for Healthcare OpenHack
 ## Ingest to FHIR
 [View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-03){: .btn } <br>
+<br>
 To utilize FHIR many organizations need a bulk data load solution. This challenge walks you through our FHIR bulk loader tool to load FHIR bundles into the Azure API for FHIR.
 
 

--- a/docs/Challenge-3.md
+++ b/docs/Challenge-3.md
@@ -7,8 +7,9 @@ nav_order: 3
 
 # Microsoft Cloud for Healthcare OpenHack
 ## Ingest to FHIR
+[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-03){: .btn } <br>
 To utilize FHIR many organizations need a bulk data load solution. This challenge walks you through our FHIR bulk loader tool to load FHIR bundles into the Azure API for FHIR.
-[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-03){: .btn }
+
 
 ## Challenge 
 + Load bulk FHIR data into Azure API for FHIR

--- a/docs/Challenge-3.md
+++ b/docs/Challenge-3.md
@@ -7,6 +7,7 @@ nav_order: 3
 
 # Microsoft Cloud for Healthcare OpenHack
 ## Ingest to FHIR
+To utilize FHIR many organizations need a bulk data load solution. This challenge walks you through our FHIR bulk loader tool to load FHIR bundles into the Azure API for FHIR.
 [View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-03){: .btn }
 
 ## Challenge 
@@ -15,11 +16,11 @@ nav_order: 3
 Access the __Ingest to FHIR Challenge__ **[here](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-03)**.
 
 ## Materials
-Powerpoint deck on loading FHIR Bundles (Synthea bundles) via FHIR-Loader
-[File-loading-side-by-side](./assets/ppts/File-loading-side-by-side.pptx)
+Powerpoint deck on loading FHIR Bundles (Synthea bundles) via FHIR-Loader <br>
+[Loading_FHIR_Bundles](./assets/ppts/File-loading-side-by-side.pptx)
 
-Bad Bundle zip file, download to your desktop, unzip then upload into FHIR-Loader
+Bad Bundle zip file, download to your desktop, unzip then upload into FHIR-Loader <br>
 [bad_bundles](./assets/zip/bad_bundles.zip)
 
-Good Bundle zip file, download to your desktop, unzip then upload into FHIR-Loader
+Good Bundle zip file, download to your desktop, unzip then upload into FHIR-Loader <br>
 [good_bundles](./assets/zip/good_bundles.zip)

--- a/docs/challenge-12.md
+++ b/docs/challenge-12.md
@@ -7,9 +7,13 @@ nav_order: 1
 # Microsoft Cloud for Healthcare OpenHack
 
 ## DICOM Service
-[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-12){: .btn }
+[View Repo on GitHub](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-12){: .btn } <br>
+<br>
+A patient's medical story often includes imaging studies. Important medical research comes from analyzing these images. This challenge walks you through sending these images to Azure using the DICOM standard method, storing the images, updating them, and retrieving them.
 
 ## Challenge 
 + Set up a Medical Imaging Server for DICOM (OSS) to work with Azure API for FHIR
++ Submit DICOM files to the service
++ View and update the files
 
 Access the __DICOM Service Challenge__ **[here](https://github.com/microsoft/openhack-mc4h/tree/main/Challenge-12)**.


### PR DESCRIPTION
Adding background paragraphs to subpages that didn't have them, syncing the challenge titles between the site and the repo and other small clean ups